### PR TITLE
fix: update magi-review trigger to only run on PR open and /magi-review comment

### DIFF
--- a/.github/workflows/magi-review.yml
+++ b/.github/workflows/magi-review.yml
@@ -2,7 +2,9 @@ name: MAGI Review
 
 on:
   pull_request:
-    types: [opened, synchronize, reopened]
+    types: [opened, reopened]
+  issue_comment:
+    types: [created]
 
 permissions:
   contents: read
@@ -11,9 +13,17 @@ permissions:
 jobs:
   magi-review:
     runs-on: ubuntu-latest
+    if: |
+      github.event_name == 'pull_request' ||
+      (github.event_name == 'issue_comment' && 
+       github.event.issue.pull_request &&
+       contains(github.event.comment.body, '/magi-review'))
+
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event_name == 'issue_comment' && format('refs/pull/{0}/head', github.event.issue.number) || '' }}
 
       - name: Google Cloud Auth
         uses: google-github-actions/auth@v2


### PR DESCRIPTION
## 변경 사항

- PR open 시에만 자동 리뷰 실행 (synchronize 제거)
- `/magi-review` 코멘트로 재실행 가능하도록 issue_comment 트리거 추가

## 동작 방식

| 트리거 | 실행 |
|:-------|:-----|
| PR 생성 (opened) | ✅ 실행 |
| PR 재열기 (reopened) | ✅ 실행 |
| 코드 push (synchronize) | ❌ 실행 안 함 |
| /magi-review 코멘트 | ✅ 재실행 |