### PR TITLE
Ignore generated .graphql.dart files by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -215,7 +215,8 @@ ignore:
 ```
 
 Generated files are ignored by default (for example: `generated/`,
-`__generated__/`, `.generated.`, `.pb.`, `.g.dart`, `.designer.cs`).
+`__generated__/`, `.generated.`, `.pb.`, `.g.dart`, `.graphql.dart`,
+`.designer.cs`).
 
 ## 📱 Slack Notifications
 

--- a/README_KO.md
+++ b/README_KO.md
@@ -215,7 +215,7 @@ ignore:
 ```
 
 생성 파일은 기본적으로 무시됩니다 (예: `generated/`, `__generated__/`,
-`.generated.`, `.pb.`, `.g.dart`, `.designer.cs`).
+`.generated.`, `.pb.`, `.g.dart`, `.graphql.dart`, `.designer.cs`).
 
 ## 📱 Slack 알림
 

--- a/src/config/loader.ts
+++ b/src/config/loader.ts
@@ -26,6 +26,7 @@ const DEFAULT_IGNORE_PATTERNS = [
   ".gen.",
   ".pb.",
   ".g.dart",
+  ".graphql.dart",
   ".designer.cs",
   "*.lock",
   "package-lock.json",

--- a/src/review/diff-analyzer.generated.test.ts
+++ b/src/review/diff-analyzer.generated.test.ts
@@ -52,6 +52,12 @@ describe("filterIgnoredFiles generated file patterns", () => {
         deletions: 2,
       },
       {
+        filename: "lib/src/graphql/user.graphql.dart",
+        status: "modified",
+        additions: 11,
+        deletions: 3,
+      },
+      {
         filename: "src/ViewModel.Designer.cs",
         status: "modified",
         additions: 9,
@@ -65,7 +71,7 @@ describe("filterIgnoredFiles generated file patterns", () => {
       },
     ];
 
-    const patterns = [".pb.", ".g.dart", ".designer.cs"];
+    const patterns = [".pb.", ".g.dart", ".graphql.dart", ".designer.cs"];
     const filtered = filterIgnoredFiles(files, patterns);
 
     expect(filtered).toHaveLength(1);


### PR DESCRIPTION
## Summary
- add `.graphql.dart` to the default generated-file ignore patterns
- extend generated-file filtering tests to cover GraphQL Dart artifacts
- update English and Korean README examples to document the default ignore list

## Testing
- pnpm test src/review/diff-analyzer.generated.test.ts